### PR TITLE
Fix #258 again

### DIFF
--- a/src/classes/ragfair.js
+++ b/src/classes/ragfair.js
@@ -250,9 +250,13 @@ function createOffer(template, onlyFunc, usePresets = true) {
 
     // Single item
     if (!preset_f.itemPresets.hasPreset(template) || !onlyFunc) {
+        let rubPrice = Math.round(itm_hf.getTemplatePrice(template) * settings.gameplay.trading.ragfairMultiplier);
         offerBase._id = template;
         offerBase.items[0]._tpl = template;
-        offerBase.requirements[0].count = Math.round(itm_hf.getTemplatePrice(template) * settings.gameplay.trading.ragfairMultiplier);
+        offerBase.requirements[0].count = rubPrice;
+        offerBase.itemsCost = rubPrice;
+        offerBase.requirementsCost = rubPrice;
+        offerBase.summaryCost = rubPrice;
         offers.push(offerBase);
     }
 


### PR DESCRIPTION
That's a patch for issue #258 (incorrect price when assembling preset) which was already fixed by 73534f3b4ee288030d69e90a013119968cfc33d3 but, unfortunately, overwritten by mistake by 7abf41400e031bdf36c67c925de10742b274c49f

Sorry for that mistake.
