### PR TITLE
Fix quest rewards #318

### DIFF
--- a/src/classes/dialogue.js
+++ b/src/classes/dialogue.js
@@ -79,10 +79,8 @@ class DialogueServer {
 			items.data = [];
 
 			rewards = itm_hf.replaceIDs(null, rewards);
-			// TODO(camo1018): Orphaned items need to be promoted to main stash.
 
 			for (let reward of rewards) {
-				reward._id = utility.generateNewItemId();
 				if (!reward.hasOwnProperty("slotId") || reward.slotId === "hideout") {
 					reward.parentId = stashId;
 					reward.slotId = "main";


### PR DESCRIPTION
Fix for #318 and also quest weapons being incomplete.

Removed an id replacement that breaks the item hierarchy so quests give full weapons now.
Added quest starter items to messages when the quest is accepted.
Factored quest items retrieval because it's the same for quest Started and quest Success.
