### PR TITLE
Fixed handover weapons for Mechanic quests

### DIFF
--- a/src/classes/quest.js
+++ b/src/classes/quest.js
@@ -154,7 +154,7 @@ function handoverQuest(pmcData, body, sessionID) {
 
     for (let condition of quest.conditions.AvailableForFinish) {
         if (condition._props.id === body.conditionId && types.includes(condition._parent)) {
-            value = condition._props.value;
+            value = parseInt(condition._props.value);
             handoverMode = condition._parent === types[0];
 
             break;

--- a/src/classes/quest.js
+++ b/src/classes/quest.js
@@ -146,30 +146,52 @@ function completeQuest(pmcData, body, sessionID) {
 function handoverQuest(pmcData, body, sessionID) {
     const quest = json.parse(json.read(db.quests[body.qid]));
     let output = item_f.itemServer.getOutput();
+    let types = ["HandoverItem", "WeaponAssembly"];
+    let handoverMode = true;
     let value = 0;
     let counter = 0;
     let amount;
 
-    // Get quest condition item count
     for (let condition of quest.conditions.AvailableForFinish) {
-        if (condition._parent === "HandoverItem" && condition._props.id === body.conditionId) {
+        if (condition._props.id === body.conditionId && types.includes(condition._parent)) {
             value = condition._props.value;
+            handoverMode = condition._parent === types[0];
+
             break;
         }
     }
 
-    if (value === 0) {
+    if (handoverMode && value === 0) {
         logger.logError("Quest handover error: condition not found or incorrect value. qid=" + body.qid + ", condition=" + body.conditionId);
         return output;
     }
 
     for (let itemHandover of body.items) {
-        amount = Math.min(itemHandover.count, value - counter);
-        counter += amount;
-        changeItemStack(pmcData, itemHandover.id, itemHandover.count - amount, output);
+        if (handoverMode) {
+            // remove the right quantity of given items
+            amount = Math.min(itemHandover.count, value - counter);
+            counter += amount;
+            changeItemStack(pmcData, itemHandover.id, itemHandover.count - amount, output);
 
-        if (counter === value) {
-            break;
+            if (counter === value) {
+                break;
+            }
+        }
+        else {
+            // for weapon assembly quests, remove the item and its children
+            let toRemove = itm_hf.findAndReturnChildren(pmcData, itemHandover.id);
+            let index = pmcData.Inventory.items.length;
+
+            // important: don't tell the client to remove the attachments, it will handle it
+            output.data.items.del.push({ "_id": itemHandover.id });
+            counter = 1;
+
+            // important: loop backward when removing items from the array we're looping on
+            while (index --> 0) {
+                if (toRemove.includes(pmcData.Inventory.items[index]._id)) {
+                    pmcData.Inventory.items.splice(index, 1);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
I've been too confident when fixing the money handover for quests and I've missed one special case: weapon assembly. Those are the quests where you need to handover a full weapon (for Mechanic).

The current code does not handle this at all, hence this fix.
Interestingly enough, the previous code (with money bug) did handle it, but with a sneaky bug: the client only sends the id of the base weapon to remove (not the attachments). So handing over a weapon would remove the receiver from the player's inventory but leave the attachments without any parent. And that's the reason I had these errors on the client logs! item xxx has no parent with id yyy.

That's one more mystery solved :)

For the records, here's a list of all condition types (from which I recon only handoverItem and WeaponAssembly trigger an item removal):
```
CompleteCondition
CounterCreator
Equipment
ExitStatus
FindItem
HandoverItem
HealthEffect
InZone
Kills
LeaveItemAtLocation
Level
Location
PlaceBeacon
Quest
Shots
Skill
TraderLoyalty
UseItem
VisitPlace
WeaponAssembly
```