### PR TITLE
Update gameVersion in test.js

### DIFF
--- a/dev/src/test.js
+++ b/dev/src/test.js
@@ -11,7 +11,7 @@ let settings = JSON.parse(readJson(__dirname + "/../../user/configs/server.json"
 
 const url = settings.ip;
 const port = settings.port;
-const gameVersion = '0.12.3.5985';
+const gameVersion = '0.12.4.6269';
 
 let integer = 0;
 


### PR DESCRIPTION
All tests are verified as passing on 0.12.4. Closes #405 and reduces confusion by not referencing non-targeted version.